### PR TITLE
fix relative data.ndjson path :bug:

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 'use strict'
 
 const fs = require('fs')
+const path = require('path')
 const ndjson = require('ndjson')
 const toArray = require('get-stream').array
 
 const positions = () => toArray(
-    fs.createReadStream('./data.ndjson')
+    fs.createReadStream(path.join(__dirname, 'data.ndjson'))
     .pipe(ndjson.parse())
 )
 


### PR DESCRIPTION
Currently, it is not possible to use the library, because the `./data.ndjson` is relative to current working directory.