### PR TITLE
return a readable stream instead of a promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,10 @@
 
 const fs = require('fs')
 const ndjson = require('ndjson')
-const toArray = require('get-stream').array
 
-const positions = () => toArray(
-    fs.createReadStream('./data.ndjson')
+const positions = () => {
+    return fs.createReadStream('./data.ndjson')
     .pipe(ndjson.parse())
-)
+}
 
 module.exports = positions

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
 		"data.ndjson"
 	],
 	"dependencies": {
-		"get-stream": "^3.0.0",
 		"ndjson": "^1.5.0"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"ndjson": "^1.5.0"
 	},
 	"devDependencies": {
+		"is-stream": "^1.1.0",
 		"lodash.isarray": "^4.0.0",
 		"lodash.isboolean": "^3.0.3",
 		"lodash.isnumber": "^3.0.3",
@@ -39,7 +40,6 @@
 		"lodash.isstring": "^4.0.1",
 		"ndjson": "^1.5.0",
 		"tape": "^4.8.0",
-		"tape-promise": "^2.0.1",
 		"vbb-lines-at": "^3.10.0",
 		"vbb-stations": "^6.0.0"
 	},


### PR DESCRIPTION
As `data.ndjson` might potentially contain a lot of data, this PR changes `require('vbb-change-positions')` to return a [readable stream](https://nodejs.org/api/stream.html#stream_readable_streams) instead of a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises).

Getting the previous behaviour is still easy, using [`get-stream`](https://www.npmjs.com/package/get-stream).